### PR TITLE
Fix resonance sampler

### DIFF
--- a/ATARI/ModelData/particle_pair.py
+++ b/ATARI/ModelData/particle_pair.py
@@ -511,9 +511,7 @@ class Particle_Pair:
             # sample resonance levels for each spin group with negative parity
             [levels, level_spacing] = sample_RRR_levels(self.energy_range, Jinfo["<D>"], ensemble=ensemble, rng=rng)
             N = len(levels)
-            # if no resonance levels sampled, dont try to sample widths
-            if N == 0:
-                continue
+
             # sample reduced widths
             gg2_samples = sample_RRR_widths(N, Jinfo["<gg2>"], Jinfo["g_dof"], rng=rng)
             gn2_samples = sample_RRR_widths(N, Jinfo["<gn2>"], Jinfo["n_dof"], rng=rng)


### PR DESCRIPTION
Removed a few lines, fixing the resonance sampler code for N = 0. Otherwise Pandas would complain about having no resonance ladders to concatenate.