### PR TITLE
Update sammy_io.py for small Gn

### DIFF
--- a/ATARI/sammy_interface/sammy_io.py
+++ b/ATARI/sammy_interface/sammy_io.py
@@ -277,8 +277,11 @@ def fill_sammy_ladder(df, particle_pair, vary_parm=False, J_ID=None):
     
     def nonzero_ifvary(row):
         for par in ["E", "Gg", "Gn1", "Gn2", "Gn3"]:
-            if row[f"vary{par}"] == 1.0 and row[par] < 1e-5:
-                row[par] = 1e-5
+            if row[f"vary{par}"] == 1.0:
+                if row[par] == 0:
+                    row[par] = 1e-6
+                elif abs(row[par]) < 1e-5:
+                    row[par] = 1e-5*np.sign(row[par])
         return row
 
     cols = df.columns.values


### PR DESCRIPTION
This fix existed in the branch I was working on. Gn is less than 1e-5 and set to vary, it should be corrected back to 1e-5 or sammy will give an error. This fix should also take into account the sign of Gn when and preserve it. @Oncure @twistfire