### PR TITLE
Adding likelihood informed model selection.

### DIFF
--- a/ATARI/PiTFAll/fnorm.py
+++ b/ATARI/PiTFAll/fnorm.py
@@ -157,7 +157,7 @@ def calculate_fnorms(ResidualMatrixDict, reactions):
     for rxn in reactions:
         R = ResidualMatrixDict[rxn]
         Rf[rxn] = np.linalg.norm(R, ord='fro')/R.size
-    ResidualMatrix_allrxns = np.hstack([ResidualMatrixDict[rxn] for rxn in reactions])
+    ResidualMatrix_allrxns = np.vstack([ResidualMatrixDict[rxn] for rxn in reactions])
     Rf["all"] = np.linalg.norm(ResidualMatrix_allrxns, ord='fro')/ResidualMatrix_allrxns.size
 
     return Rf, ResidualMatrix_allrxns


### PR DESCRIPTION
`FitAndEliminateOPT` has two new arguments for `Wigner_informed` and `PorterThomas_informed`, which allow for likelihood informed model selection. If either of these are used, `FitAndEliminate` needs a `particle_pair` argument to run.

I am also realizing that I should add the objective values to the output dictionary for the elimination process, but that is a job for another day.